### PR TITLE
Eliminar el filtro de tipo de examen en la tabla de casos y ajustar l…

### DIFF
--- a/src/features/dashboard/settings/SessionTimeoutSettings.tsx
+++ b/src/features/dashboard/settings/SessionTimeoutSettings.tsx
@@ -1,5 +1,5 @@
 import { Card } from '@shared/components/ui/card';
-import { Clock, Shield, CheckCircle } from 'lucide-react';
+import { Clock, Shield } from 'lucide-react';
 import { useAuth } from '@app/providers/AuthContext'
 import { SESSION_TIMEOUT_OPTIONS } from '@shared/hooks/useSessionTimeoutSettings'
 import { RadioGroup, RadioGroupItem } from '@shared/components/ui/radio-group'

--- a/src/shared/components/cases/CasesTable.tsx
+++ b/src/shared/components/cases/CasesTable.tsx
@@ -55,7 +55,6 @@ const CasesTable: React.FC<CasesTableProps> = React.memo(
 		const [searchTerm, setSearchTerm] = useState('')
 		const [statusFilter, setStatusFilter] = useState<string>('all')
 		const [branchFilter, setBranchFilter] = useState<string>('all')
-		const [examTypeFilter, setExamTypeFilter] = useState<string>('all')
 		const [sortField, setSortField] = useState<SortField>('created_at')
 		const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
 		const [selectedCaseForGenerate, setSelectedCaseForGenerate] = useState<MedicalRecord | null>(null)
@@ -274,7 +273,6 @@ const CasesTable: React.FC<CasesTableProps> = React.memo(
 			const hasActiveFilters =
 				statusFilter !== 'all' ||
 				branchFilter !== 'all' ||
-				examTypeFilter !== 'all' ||
 				showPdfReadyOnly ||
 				selectedDoctors.length > 0 ||
 				(searchTerm && searchTerm.trim() !== '') ||
@@ -309,7 +307,7 @@ const CasesTable: React.FC<CasesTableProps> = React.memo(
 				const matchesBranch = branchFilter === 'all' || normalize(case_.branch) === normalize(branchFilter)
 
 				// Exam type filter
-				const matchesExamType = examTypeFilter === 'all' || case_.exam_type === examTypeFilter
+				const matchesExamType = true // No exam type filter active
 
 				// PDF ready filter
 				let matchesPdfReady = true
@@ -370,7 +368,6 @@ const CasesTable: React.FC<CasesTableProps> = React.memo(
 			cases,
 			statusFilter,
 			branchFilter,
-			examTypeFilter,
 			sortField,
 			sortDirection,
 			showPdfReadyOnly,


### PR DESCRIPTION
…a lógica de filtrado correspondiente. Simplificar la importación de íconos en la configuración de tiempo de sesión.