### PR TITLE
Implementar manejo de superposiciones globales para modales y paneles…

### DIFF
--- a/src/features/dashboard/layouts/Header.tsx
+++ b/src/features/dashboard/layouts/Header.tsx
@@ -11,9 +11,9 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
 			<header className="flex lg:hidden justify-between items-center px-3 sm:px-6 py-2 sm:py-3">
 				{/* Mobile menu button and search */}
 				<div className="flex items-center gap-3">
-					<button
+                    <button
 						onClick={onMenuClick}
-						className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-none"
+                        className="mobile-hamburger p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-none"
 					>
 						<Menu className="w-5 h-5 text-gray-600 dark:text-gray-400" />
 					</button>

--- a/src/features/dashboard/layouts/Layout.tsx
+++ b/src/features/dashboard/layouts/Layout.tsx
@@ -5,6 +5,7 @@ import { useDarkMode } from '@shared/hooks/useDarkMode'
 import { useFullscreenDetection } from '@shared/hooks/useFullscreenDetection'
 import Sidebar from '@shared/components/Sidebar'
 import {Menu} from 'lucide-react'
+import { useGlobalOverlayOpen } from '@shared/hooks/useGlobalOverlayOpen'
 
 const Layout: React.FC = () => {
 	const { isDark, toggleDarkMode } = useDarkMode()
@@ -27,7 +28,10 @@ const Layout: React.FC = () => {
 		setSidebarExpanded(false)
 	}
 
-	return (
+  // Contar sidebar móvil como overlay abierto para ocultar hamburguesa
+  useGlobalOverlayOpen(sidebarOpen)
+
+  return (
 		<div className="min-h-screen bg-white dark:bg-background">
 			{/* Mobile overlay */}
 			<AnimatePresence>
@@ -68,7 +72,7 @@ const Layout: React.FC = () => {
 			{!isFullscreenMode && (
 				<button
 					onClick={toggleSidebar}
-					className="lg:hidden flex fixed items-center justify-center p-2 bg-white/80 dark:bg-background/80 backdrop-blur-sm border border-input rounded-lg shadow-lg top-4 right-4 z-50"
+            className="mobile-hamburger lg:hidden flex fixed items-center justify-center p-2 bg-white/80 dark:bg-background/80 backdrop-blur-sm border border-input rounded-lg shadow-lg top-4 right-4 z-50"
 				>
 					<Menu className="h-5 w-5 text-gray-600 dark:text-gray-400 " />
 				</button>

--- a/src/features/dashboard/patients/PatientsList.tsx
+++ b/src/features/dashboard/patients/PatientsList.tsx
@@ -357,14 +357,13 @@ const PatientsList: React.FC<PatientsListProps> = React.memo(
 										className="bg-white dark:bg-gray-800/50 p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:shadow-md transition-transform duration-200 cursor-pointer"
 										onClick={() => handlePatientClick(patient)}
 									>
-										<div className="flex items-center mb-2">
-											<div className="ml-2 min-w-0">
-												<p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-													{patient.full_name}
-												</p>
-												<p className="text-xs text-gray-500 dark:text-gray-400">Cédula: {patient.id_number}</p>
-											</div>
-										</div>
+                                        <div className="flex items-center mb-2">
+                                            <div className="ml-2 min-w-0">
+                                                <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                                                    {patient.full_name}
+                                                </p>
+                                            </div>
+                                        </div>
 
 										<div className="grid grid-cols-2 gap-2 text-xs">
 											<div className="col-span-2">

--- a/src/features/form/pages/Form.tsx
+++ b/src/features/form/pages/Form.tsx
@@ -19,6 +19,7 @@ import { useFullscreenDetection } from '@shared/hooks/useFullscreenDetection'
 
 // Import Menu icon for mobile sidebar toggle
 import { Menu } from 'lucide-react'
+import { useGlobalOverlayOpen } from '@shared/hooks/useGlobalOverlayOpen'
 
 // Lazy loaded components
 import {
@@ -79,6 +80,9 @@ function FormContent() {
 	const form = useForm<FormValues>({ defaultValues: getInitialFormValues() })
 	const { toast } = useToast()
 	const medicalFormRef = useRef<MedicalFormRef>(null)
+
+  // Si el sidebar móvil está abierto, ocultar el botón hamburguesa globalmente
+  useGlobalOverlayOpen(sidebarOpen)
 
 	// Determine active tab based on current route
 	useEffect(() => {
@@ -176,10 +180,10 @@ function FormContent() {
 						Limpiar
 					</Button>
 				)}
-				{!isFullscreenMode && (
+        {!isFullscreenMode && (
 					<button
 						onClick={() => setSidebarOpen(!sidebarOpen)}
-						className="lg:hidden flex items-center justify-center p-2 bg-white/80 dark:bg-background/80 backdrop-blur-sm border border-input rounded-lg shadow-lg"
+            className="mobile-hamburger lg:hidden flex items-center justify-center p-2 bg-white/80 dark:bg-background/80 backdrop-blur-sm border border-input rounded-lg shadow-lg"
 					>
 						<Menu className="h-5 w-5 text-gray-600 dark:text-gray-400" />
 					</button>

--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,13 @@
   }
 }
 
+/* Ocultar botón hamburguesa móvil cuando haya overlay/modal abierto */
+@media (max-width: 1024px) {
+  body.has-overlay-open .mobile-hamburger {
+    display: none !important;
+  }
+}
+
 ::-moz-selection {
   /* Para Firefox */
   background: hsl(330 81% 60%);

--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -269,9 +269,10 @@ const Sidebar: React.FC<SidebarProps> = ({ onClose, isExpanded = false, isMobile
 	const isOwner = profile?.role === 'owner'
 	const isEmployee = profile?.role === 'employee'
 
-	return (
-		<aside className="bg-white/80 dark:bg-background/50 shadow-lg shadow-primary/50 backdrop-blur-[10px] flex flex-col justify-between h-screen py-4 sm:py-6 px-2 sm:px-4 gap-4 border-gray-600 text-gray-700 dark:text-white ease-in-out overflow-hidden border-r border-input">
-			<div className="flex flex-col items-start gap-4">
+  return (
+		<aside className="bg-white/80 dark:bg-background/50 shadow-lg shadow-primary/50 backdrop-blur-[10px] flex flex-col h-screen py-4 sm:py-6 px-2 sm:px-4 gap-0 border-gray-600 text-gray-700 dark:text-white ease-in-out overflow-hidden border-r border-input">
+			{/* Zona scrollable: navegación y grupos */}
+			<div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-1 flex flex-col items-start gap-4 scrollbar-hide">
 				<div className="flex justify-between items-center w-full mb-2 sm:mb-4">
 					<a
 						href="https://conspat.solware.agency/"
@@ -459,7 +460,8 @@ const Sidebar: React.FC<SidebarProps> = ({ onClose, isExpanded = false, isMobile
 				</div>
 			</div>
 
-			<div className="flex flex-col justify-center gap-1">
+			{/* Pie fijo: Ajustes, tema y salir */}
+			<div className="shrink-0 flex flex-col justify-center gap-1 border-t border-input pt-2 sm:pt-3">
 				{isEmployee && (
 					<NavItem
 						to="/settings"

--- a/src/shared/components/cases/RequestCaseModal.tsx
+++ b/src/shared/components/cases/RequestCaseModal.tsx
@@ -8,6 +8,8 @@ import { useAuth } from '@app/providers/AuthContext'
 import { useUserProfile } from '@shared/hooks/useUserProfile'
 import { updateMedicalRecordWithLog, createOrUpdateImmunoRequest } from '@lib/supabase-service'
 import type { MedicalRecord } from '@lib/supabase-service'
+import { useBodyScrollLock } from '@shared/hooks/useBodyScrollLock'
+import { useGlobalOverlayOpen } from '@shared/hooks/useGlobalOverlayOpen'
 
 interface GenerateCaseModalProps {
 	case_: MedicalRecord | null
@@ -22,6 +24,8 @@ const RequestCaseModal: React.FC<GenerateCaseModalProps> = ({ case_, isOpen, onC
 	const { toast } = useToast()
 	const { user } = useAuth()
 	const { profile } = useUserProfile()
+  useBodyScrollLock(isOpen)
+  useGlobalOverlayOpen(isOpen)
 
 	// Determine case type from exam_type
 	const getCaseType = (examType: string): 'biopsia' | 'inmunohistoquimica' | 'citologia' => {

--- a/src/shared/components/cases/StepsCaseModal.tsx
+++ b/src/shared/components/cases/StepsCaseModal.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@lib/supabase/config'
 import { X, User, ArrowLeft, ArrowRight, Sparkles, Heart, Stethoscope, Microscope } from 'lucide-react'
 import { useToast } from '@shared/hooks/use-toast'
 import { useBodyScrollLock } from '@shared/hooks/useBodyScrollLock'
+import { useGlobalOverlayOpen } from '@shared/hooks/useGlobalOverlayOpen'
 
 interface MedicalRecord {
 	id?: string
@@ -50,7 +51,8 @@ const StepsCaseModal: React.FC<StepsCaseModalProps> = ({ case_, isOpen, onClose,
 	const [isCompleting, setIsCompleting] = useState(false)
 	const [isSaving, setIsSaving] = useState(false)
 	const { toast } = useToast()
-	useBodyScrollLock(isOpen)
+    useBodyScrollLock(isOpen)
+    useGlobalOverlayOpen(isOpen)
 	const handleNext = () => {
 		if (activeStep < steps.length - 1) {
 			setActiveStep((prev) => prev + 1)

--- a/src/shared/components/cases/UnifiedCaseModal.tsx
+++ b/src/shared/components/cases/UnifiedCaseModal.tsx
@@ -45,6 +45,7 @@ import {
 	autoCorrectDecimalAmount,
 } from '@shared/utils/number-utils'
 import { useBodyScrollLock } from '@shared/hooks/useBodyScrollLock'
+import { useGlobalOverlayOpen } from '@shared/hooks/useGlobalOverlayOpen'
 
 interface ChangeLogEntry {
 	id: string
@@ -80,7 +81,8 @@ interface ImmunoRequest {
 }
 
 const UnifiedCaseModal: React.FC<CaseDetailPanelProps> = React.memo(({ case_, isOpen, onClose, onSave, onDelete }) => {
-	useBodyScrollLock(isOpen)
+    useBodyScrollLock(isOpen)
+    useGlobalOverlayOpen(isOpen)
 	const { toast } = useToast()
 	const { user } = useAuth()
 	const { profile } = useUserProfile()

--- a/src/shared/components/patients/PatientHistoryModal.tsx
+++ b/src/shared/components/patients/PatientHistoryModal.tsx
@@ -11,6 +11,7 @@ import type { MedicalRecord } from '@lib/supabase-service'
 import { Button } from '@shared/components/ui/button'
 import { Input } from '@shared/components/ui/input'
 import { useBodyScrollLock } from '@shared/hooks/useBodyScrollLock'
+import { useGlobalOverlayOpen } from '@shared/hooks/useGlobalOverlayOpen'
 
 interface PatientHistoryModalProps {
   isOpen: boolean
@@ -27,7 +28,8 @@ interface PatientHistoryModalProps {
 
 const PatientHistoryModal: React.FC<PatientHistoryModalProps> = ({ isOpen, onClose, patient }) => {
   const [searchTerm, setSearchTerm] = useState('')
-	useBodyScrollLock(isOpen)
+  useBodyScrollLock(isOpen)
+  useGlobalOverlayOpen(isOpen)
   
   // Fetch patient's medical records
   const { data, isLoading, error, refetch } = useQuery({

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -12,18 +12,36 @@ const DialogPortal = DialogPrimitive.Portal
 
 const DialogClose = DialogPrimitive.Close
 
+// Contador local para overlays de Radix
+let radixDialogOverlayCount = 0
+
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    )}
-    {...props}
-  />
+  (() => {
+    React.useEffect(() => {
+      radixDialogOverlayCount += 1
+      document.body.classList.add('has-overlay-open')
+      return () => {
+        radixDialogOverlayCount = Math.max(0, radixDialogOverlayCount - 1)
+        if (radixDialogOverlayCount === 0) {
+          document.body.classList.remove('has-overlay-open')
+        }
+      }
+    }, [])
+
+    return (
+      <DialogPrimitive.Overlay
+        ref={ref}
+        className={cn(
+          "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          className
+        )}
+        {...props}
+      />
+    )
+  })()
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 

--- a/src/shared/components/ui/stat-detail-panel.tsx
+++ b/src/shared/components/ui/stat-detail-panel.tsx
@@ -5,6 +5,7 @@ import { Button } from '@shared/components/ui/button'
 import { format } from 'date-fns'
 import { es } from 'date-fns/locale'
 import { useBodyScrollLock } from '@shared/hooks/useBodyScrollLock'
+import { useGlobalOverlayOpen } from '@shared/hooks/useGlobalOverlayOpen'
 
 export type StatType =
 	| 'totalRevenue'
@@ -36,6 +37,7 @@ const StatDetailPanel: React.FC<StatDetailPanelProps> = ({
 	selectedMonth,
 }) => {
   useBodyScrollLock(isOpen)
+  useGlobalOverlayOpen(isOpen)
 	const formatCurrency = (amount: number) => {
 		return new Intl.NumberFormat('es-VE', {
 			style: 'currency',

--- a/src/shared/hooks/useGlobalOverlayOpen.ts
+++ b/src/shared/hooks/useGlobalOverlayOpen.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react'
+
+// Contador global para manejar múltiples modales/paneles abiertos a la vez
+let openOverlaysCount = 0
+
+/**
+ * Marca el <body> con la clase `has-overlay-open` cuando isOpen es true.
+ * Funciona de forma segura con múltiples instancias en paralelo.
+ */
+export function useGlobalOverlayOpen(isOpen: boolean) {
+  const isAppliedRef = useRef(false)
+
+  useEffect(() => {
+    if (isOpen && !isAppliedRef.current) {
+      openOverlaysCount += 1
+      isAppliedRef.current = true
+      document.body.classList.add('has-overlay-open')
+    } else if (!isOpen && isAppliedRef.current) {
+      openOverlaysCount = Math.max(0, openOverlaysCount - 1)
+      isAppliedRef.current = false
+      if (openOverlaysCount === 0) {
+        document.body.classList.remove('has-overlay-open')
+      }
+    }
+
+    return () => {
+      if (isAppliedRef.current) {
+        openOverlaysCount = Math.max(0, openOverlaysCount - 1)
+        isAppliedRef.current = false
+        if (openOverlaysCount === 0) {
+          document.body.classList.remove('has-overlay-open')
+        }
+      }
+    }
+  }, [isOpen])
+}
+
+


### PR DESCRIPTION
…. Se agregó el hook `useGlobalOverlayOpen` para gestionar la clase `has-overlay-open` en el body, mejorando la experiencia de usuario al ocultar el botón hamburguesa en dispositivos móviles cuando hay un modal abierto. Se realizaron ajustes en el CSS y se actualizaron varios componentes para integrar esta funcionalidad.