### PR TITLE
feat: add URL parameter handling for demo credentials in LoginForm

### DIFF
--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -27,6 +27,24 @@ function LoginForm() {
 		},
 	})
 
+	// Efecto para detectar parámetros de URL y pre-llenar campos
+	useEffect(() => {
+		const urlParams = new URLSearchParams(window.location.search)
+		const demoEmail = urlParams.get('demo')
+
+		if (demoEmail === 'true') {
+			setEmail('juegosgeorge0502@gmail.com')
+			setPassword('george0502')
+			toast({
+				title: 'Credenciales de prueba cargadas',
+				description: 'Haz clic en "Iniciar sesión" para continuar',
+			})
+
+			// Limpiar la URL
+			window.history.replaceState({}, '', window.location.pathname)
+		}
+	}, [])
+
 	// Suscripción Realtime por email para detectar aprobación estando en login
 	useEffect(() => {
 		if (!awaitingApproval || !email) return


### PR DESCRIPTION
- Implemented useEffect to check for 'demo' URL parameter and pre-fill email and password fields with demo credentials.
- Added toast notification to inform users when demo credentials are loaded.
- Cleared URL parameters after loading demo credentials to enhance user experience.